### PR TITLE
fix typo in less

### DIFF
--- a/src/less/react-checkbox-tree.less
+++ b/src/less/react-checkbox-tree.less
@@ -1,8 +1,8 @@
 @rct-icon-color: #33c;
 @rct-label-hover: rgba(red(@rct-icon-color), green(@rct-icon-color), blue(@rct-icon-color), .1);
 @rct-label-active: rgba(red(@rct-icon-color), green(@rct-icon-color), blue(@rct-icon-color), .15);
-@rct-label-hover: rgba(red(@rct-icon-color), green(@rct-icon-color), blue(@rct-icon-color), .1);
-@rct-label-active: rgba(red(@rct-icon-color), green(@rct-icon-color), blue(@rct-icon-color), .2);
+@rct-clickable-hover: rgba(red(@rct-icon-color), green(@rct-icon-color), blue(@rct-icon-color), .1);
+@rct-clickable-focus: rgba(red(@rct-icon-color), green(@rct-icon-color), blue(@rct-icon-color), .2);
 
 .react-checkbox-tree {
   font-size: 16px;


### PR DESCRIPTION
Typo in `src/less/react-checkbox-tree.less`
Fixes #88 