### PR TITLE
eslint-disable-line comment - fixes #95

### DIFF
--- a/src/js/TreeNode.js
+++ b/src/js/TreeNode.js
@@ -198,7 +198,7 @@ class TreeNode extends React.Component {
         const inputId = `${treeId}-${String(value).split(' ').join('_')}`;
 
         const render = [(
-            <label key={0} htmlFor={inputId}>
+            <label key={0} htmlFor={inputId}> {/* eslint-disable-line jsx-a11y/label-has-for */}
                 <NativeCheckbox
                     checked={checked === 1}
                     disabled={disabled}


### PR DESCRIPTION
I just added an `eslint-disable-line` comment to stop the error.

I do not understand the problem but this rule is deprecated.

https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-for.md