### PR TITLE
Add expandOpen to TS declarations

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -17,6 +17,7 @@ declare module "react-checkbox-tree" {
         uncheck?: JSX.Element;
         halfCheck?: JSX.Element;
         expandClose?: JSX.Element;
+        expandOpen?: JSX.Element;
         expandAll?: JSX.Element;
         collapseAll?: JSX.Element;
         parentClose?: JSX.Element;


### PR DESCRIPTION
expandOpend is missing from typescript declarations (index.d.ts). This commit adds the missing icon def.