### PR TITLE
Support useTopNode option

### DIFF
--- a/src/js/CheckboxTree.js
+++ b/src/js/CheckboxTree.js
@@ -280,6 +280,7 @@ class CheckboxTree extends React.Component {
                     onCheck={this.onCheck}
                     onClick={onClick && this.onNodeClick}
                     onExpand={this.onExpand}
+                    useTopNode={useTopNode}
                 >
                     {children}
                 </TreeNode>

--- a/src/js/NodeModel.js
+++ b/src/js/NodeModel.js
@@ -125,7 +125,7 @@ class NodeModel {
             }
             // Percolate check status down to all children
             flatNode.children.forEach((child) => {
-                this.toggleChecked(child, useTopNode ? false : isChecked, noCascade);
+                this.toggleChecked(child, useTopNode ? false : isChecked, noCascade, useTopNode);
             });
         }
 

--- a/src/js/NodeModel.js
+++ b/src/js/NodeModel.js
@@ -109,7 +109,7 @@ class NodeModel {
         return this;
     }
 
-    toggleChecked(node, isChecked, noCascade) {
+    toggleChecked(node, isChecked, noCascade, useTopNode) {
         const flatNode = this.flatNodes[node.value];
 
         if (flatNode.isLeaf || noCascade) {
@@ -120,9 +120,12 @@ class NodeModel {
             // Set the check status of a leaf node or an uncoupled parent
             this.toggleNode(node.value, 'checked', isChecked);
         } else {
+            if (useTopNode) {
+                this.toggleNode(node.value, 'checked', isChecked);
+            }
             // Percolate check status down to all children
             flatNode.children.forEach((child) => {
-                this.toggleChecked(child, isChecked, noCascade);
+                this.toggleChecked(child, useTopNode ? false : isChecked, noCascade);
             });
         }
 

--- a/src/js/TreeNode.js
+++ b/src/js/TreeNode.js
@@ -35,6 +35,7 @@ class TreeNode extends React.Component {
         showCheckbox: PropTypes.bool,
         title: PropTypes.string,
         onClick: PropTypes.func,
+        useTopNode: PropTypes.bool,
     };
 
     static defaultProps = {
@@ -56,8 +57,9 @@ class TreeNode extends React.Component {
     }
 
     onCheck() {
-        const { value, onCheck } = this.props;
+        const { value, onCheck, checked, useTopNode } = this.props;
 
+        if (checked === 2 && useTopNode) return;
         onCheck({ value, checked: this.getCheckState({ toggle: true }) });
     }
 


### PR DESCRIPTION
Wrote this because I wanted to do something that looks like [GitHub token creator](https://github.com/settings/tokens/new).

It does what was mentioned in #13, particularly the 2nd model:

> 2. **Record upper-most nodes in `checked`**. Here, we care about top-most checked nodes; the component needs to be intelligent enough to only record nodes that do not have a parent node checked. This is the model you are suggesting.
