### PR TITLE
#145: Change JSX.Element to React.ReactNode in typings

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2,27 +2,27 @@ import * as React from 'react';
 
 declare module "react-checkbox-tree" {
     interface Node {
-        label: JSX.Element;
+        label: React.ReactNode;
         value: string;
         children?: Array<Node>;
         className?: string;
         disabled?: boolean;
-        icon?: JSX.Element;
+        icon?: React.ReactNode;
         showCheckbox?: boolean;
         title?: string;
     }
 
     interface Icons {
-        check?: JSX.Element;
-        uncheck?: JSX.Element;
-        halfCheck?: JSX.Element;
-        expandOpen?: JSX.Element;
-        expandClose?: JSX.Element;
-        expandAll?: JSX.Element;
-        collapseAll?: JSX.Element;
-        parentClose?: JSX.Element;
-        parentOpen?: JSX.Element;
-        leaf?: JSX.Element;
+        check?: React.ReactNode;
+        uncheck?: React.ReactNode;
+        halfCheck?: React.ReactNode;
+        expandOpen?: React.ReactNode;
+        expandClose?: React.ReactNode;
+        expandAll?: React.ReactNode;
+        collapseAll?: React.ReactNode;
+        parentClose?: React.ReactNode;
+        parentOpen?: React.ReactNode;
+        leaf?: React.ReactNode;
     }
 
     interface Language {


### PR DESCRIPTION
Hi @jakezatecky,

With advanced usage of your lib regarding icons, I also stumbled upon the issue in #145.

TypeScript understands JSX.Element when writing the components directly in line, but React.ReactNode seems to be the far more general approach, which allows for all possible components to be passed as argument, whereas JSX.Element is only objects that are returned from React.createElement.

Source: https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/issues/57#issuecomment-451582715

It would be great to have this PR included in the next release to fix these issues for TypeScript users.

Kind Regards,
Florian