### PR TITLE
#171 - Allow Parent Nodes to Have an Empty `children` Array

### DIFF
--- a/src/js/NodeModel.js
+++ b/src/js/NodeModel.js
@@ -52,7 +52,7 @@ class NodeModel {
     }
 
     nodeHasChildren(node) {
-        return Array.isArray(node.children) && node.children.length > 0;
+        return Array.isArray(node.children);
     }
 
     getDisabledState(node, parent, disabledProp, noCascade) {

--- a/test/CheckboxTree.js
+++ b/test/CheckboxTree.js
@@ -181,6 +181,56 @@ describe('<CheckboxTree />', () => {
                 { children: [null, null] },
             );
         });
+
+        it('should render a node with no "children" array as a leaf', () => {
+            const wrapper = shallow(
+                <CheckboxTree
+                    nodes={[
+                        { value: 'jupiter', label: 'Jupiter' },
+                    ]}
+                />,
+            );
+
+            assert.equal(false, wrapper.find(TreeNode).prop('isParent'));
+            assert.equal(true, wrapper.find(TreeNode).prop('isLeaf'));
+        });
+
+        it('should render a node with an empty "children" array as a parent', () => {
+            const wrapper = shallow(
+                <CheckboxTree
+                    nodes={[
+                        {
+                            value: 'jupiter',
+                            label: 'Jupiter',
+                            children: [],
+                        },
+                    ]}
+                />,
+            );
+
+            assert.equal(true, wrapper.find(TreeNode).prop('isParent'));
+            assert.equal(false, wrapper.find(TreeNode).prop('isLeaf'));
+        });
+
+        it('should render a node with a non-empty "children" array as a parent', () => {
+            const wrapper = shallow(
+                <CheckboxTree
+                    nodes={[
+                        {
+                            value: 'jupiter',
+                            label: 'Jupiter',
+                            children: [
+                                { value: 'io', label: 'Io' },
+                                { value: 'europa', label: 'Europa' },
+                            ],
+                        },
+                    ]}
+                />,
+            );
+
+            assert.equal(true, wrapper.find(TreeNode).prop('isParent'));
+            assert.equal(false, wrapper.find(TreeNode).prop('isLeaf'));
+        });
     });
 
     describe('noCascade', () => {


### PR DESCRIPTION
In computer science terms, a node without any children is a "leaf". But in practical use, it's common to run into structures (e.g. empty folders in file systems) where a node is still a parent because it does not _yet_ have children but has the capacity to have children in the future.

Closes #171.