### PR TITLE
[Feature Request] onCheck/onClick/onExpand returns node object w/ same data passed at invocation

### DIFF
--- a/src/js/NodeModel.js
+++ b/src/js/NodeModel.js
@@ -51,6 +51,9 @@ class NodeModel {
                 disabled: this.getDisabledState(node, parent, disabled, noCascade),
                 treeDepth: depth,
                 index,
+                extraKeys: Object.entries(node)
+                    .filter(([key]) => !CheckModel.flatKeys.includes(key))
+                    .reduce((acc, [key, val]) => ({ ...acc, [key]: val }), {}),
             };
             this.flattenNodes(node.children, node, depth + 1);
         });

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -2,6 +2,20 @@ const CheckModel = {
     ALL: 'all',
     PARENT: 'parent',
     LEAF: 'leaf',
+    flatKeys: [
+        'label',
+        'value',
+        'children',
+        'parent',
+        'isChild',
+        'isParent',
+        'isLeaf',
+        'showCheckbox',
+        'disabled',
+        'treeDepth',
+        'index',
+        'extraKeys',
+    ],
 };
 
 export default { CheckModel };

--- a/test/CheckboxTree.js
+++ b/test/CheckboxTree.js
@@ -859,8 +859,9 @@ describe('<CheckboxTree />', () => {
                         {
                             value: 'jupiter',
                             label: 'Jupiter',
+                            test1: '123',
                             children: [
-                                { value: 'io', label: 'Io' },
+                                { value: 'io', label: 'Io', test2: '456' },
                                 { value: 'europa', label: 'Europa' },
                             ],
                         },
@@ -884,6 +885,9 @@ describe('<CheckboxTree />', () => {
                 treeDepth: 1,
                 index: 0,
                 parentValue: 'jupiter',
+                extraKeys: {
+                    test2: '456',
+                },
             };
             const expectedParentMetadata = {
                 value: 'jupiter',
@@ -893,6 +897,9 @@ describe('<CheckboxTree />', () => {
                 treeDepth: 0,
                 index: 0,
                 parentValue: undefined,
+                extraKeys: {
+                    test1: '123',
+                },
             };
 
             // onCheck


### PR DESCRIPTION
It would be really nice if we could do the following:


```jsx
onCheck = (newChecked, selectedNode) => {
  const { myCustomKey, requiredKey } = selectedNode;
  // do something with this myCustomKey
}
<CheckboxTree nodes=[{ ...allRequiredKeys, ...myCustomKeys }] onCheck={this.onCheck}/>
```

At the moment, only the required keys are returned and therefore `myCustomKey` above is undefined.