### PR TITLE
Prevent all node to be checked when filtering tree

### DIFF
--- a/src/js/CheckboxTree.js
+++ b/src/js/CheckboxTree.js
@@ -193,6 +193,10 @@ class CheckboxTree extends React.Component {
     }
 
     isEveryChildChecked(node) {
+        if (!node.children || node.children.length === 0) {
+            return this.state.model.getNode(node.value).checked;
+        }
+
         return node.children.every(
             (child) => this.state.model.getNode(child.value).checkState === 1,
         );

--- a/src/js/CheckboxTree.js
+++ b/src/js/CheckboxTree.js
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import isEqual from 'lodash/isEqual';
-import nanoid from 'nanoid';
+import { nanoid } from 'nanoid';
 import PropTypes from 'prop-types';
 import React from 'react';
 

--- a/src/js/NodeModel.js
+++ b/src/js/NodeModel.js
@@ -57,7 +57,7 @@ class NodeModel {
     }
 
     nodeHasChildren(node) {
-        return Array.isArray(node.children);
+        return Array.isArray(node.children) && node.children.length > 0;
     }
 
     getDisabledState(node, parent, disabledProp, noCascade) {
@@ -163,6 +163,10 @@ class NodeModel {
     }
 
     isEveryChildChecked(node) {
+        if (!node.children || node.children.length === 0) {
+            return this.getNode(node.value).checked;
+        }
+
         return node.children.every((child) => this.getNode(child.value).checked);
     }
 


### PR DESCRIPTION
See https://github.com/jakezatecky/react-checkbox-tree/issues/196

There is a strange behaviour for the leaf node.

On first render, there are correctly set as a leaf with a `children: undefined` property.

But after filtering, they got a `children: []` prop.

Thus the `isLeaf` value is set wrong (which you can see on the filter example, when filtering the leaf suddenly get a directory icon).
And it also changes the returned values of the checked function, checking everything (even if the actual checked state is still untouched).

