### PR TITLE
fix: prevent all node to be checked when filtering tree

### DIFF
--- a/examples/src/js/FilterExample.js
+++ b/examples/src/js/FilterExample.js
@@ -146,7 +146,7 @@ class FilterExample extends React.Component {
             // Or a children has a matching node
             children.length
         ) {
-            filtered.push({ ...node, children });
+            filtered.push({...node, ...children.length && {children}});
         }
 
         return filtered;


### PR DESCRIPTION
Hi friends, I updated the following Example to fix #196  issue. If Instead of passing an empty array as a child, we don't pass children, this issue won't occur. I believe we have to prevent happening this bug inside the component, but it's the quickest solution that I've found.