### PR TITLE
Optimize large list performance 

### DIFF
--- a/src/js/CheckboxTree.js
+++ b/src/js/CheckboxTree.js
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import isEqual from 'lodash/isEqual';
+import memoize from 'lodash/memoize';
 import { nanoid } from 'nanoid';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -12,7 +13,6 @@ import iconsShape from './shapes/iconsShape';
 import languageShape from './shapes/languageShape';
 import listShape from './shapes/listShape';
 import nodeShape from './shapes/nodeShape';
-import { memoize } from 'lodash';
 
 class CheckboxTree extends React.Component {
     static propTypes = {
@@ -104,7 +104,7 @@ class CheckboxTree extends React.Component {
         this.onExpandAll = this.onExpandAll.bind(this);
         this.onCollapseAll = this.onCollapseAll.bind(this);
 
-        this.combineMemorized = memoize((icons1, icons2) => ({...icons1, ...icons2})).bind(this)
+        this.combineMemorized = memoize((icons1, icons2) => ({ ...icons1, ...icons2 })).bind(this);
     }
 
     // eslint-disable-next-line react/sort-comp

--- a/src/js/CheckboxTree.js
+++ b/src/js/CheckboxTree.js
@@ -12,6 +12,7 @@ import iconsShape from './shapes/iconsShape';
 import languageShape from './shapes/languageShape';
 import listShape from './shapes/listShape';
 import nodeShape from './shapes/nodeShape';
+import { memoize } from 'lodash';
 
 class CheckboxTree extends React.Component {
     static propTypes = {
@@ -102,6 +103,8 @@ class CheckboxTree extends React.Component {
         this.onNodeClick = this.onNodeClick.bind(this);
         this.onExpandAll = this.onExpandAll.bind(this);
         this.onCollapseAll = this.onCollapseAll.bind(this);
+
+        this.combineMemorized = memoize((icons1, icons2) => ({...icons1, ...icons2})).bind(this)
     }
 
     // eslint-disable-next-line react/sort-comp
@@ -250,7 +253,7 @@ class CheckboxTree extends React.Component {
                     expandOnClick={expandOnClick}
                     expanded={flatNode.expanded}
                     icon={node.icon}
-                    icons={{ ...defaultIcons, ...icons }}
+                    icons={this.combineMemorized(defaultIcons, icons)}
                     label={node.label}
                     lang={lang}
                     optimisticToggle={optimisticToggle}

--- a/src/js/TreeNode.js
+++ b/src/js/TreeNode.js
@@ -7,7 +7,7 @@ import NativeCheckbox from './NativeCheckbox';
 import iconsShape from './shapes/iconsShape';
 import languageShape from './shapes/languageShape';
 
-class TreeNode extends React.Component {
+class TreeNode extends React.PureComponent {
     static propTypes = {
         checked: PropTypes.number.isRequired,
         disabled: PropTypes.bool.isRequired,


### PR DESCRIPTION
Optimized rendering of a large list of nodes.
The problem was that with checking any node of the tree, all nodes were re-rendered, even if they did not change.
The solution to this problem is quite simple: make the node component a pure one and make sure that the props of this component are not re-created on every rendering.

# Impact on performance. 
Measured on a tree of 2100 visible nodes. OS: Windows 10 x64 with Ryzen 5 2600 3.40 GHz
## Before
620-650 ms
![image](https://user-images.githubusercontent.com/20888345/106862336-094de100-66d8-11eb-98e8-4c13853aee31.png)
## After
160-180 ms
![image](https://user-images.githubusercontent.com/20888345/106862421-2a163680-66d8-11eb-814b-e920e622a27c.png)

