### PR TITLE
Use string union for `checkModel` and `direction`

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -42,9 +42,9 @@ declare module "react-checkbox-tree" {
     interface CheckboxProps {
         nodes: Array<Node>;
 
-        checkModel?: string;
+        checkModel?: 'leaf' | 'all';
         checked?: Array<string>;
-        direction?: string;
+        direction?: 'ltr' | 'rtl';
         disabled?: boolean;
         expandDisabled?: boolean;
         expandOnClick?: boolean;


### PR DESCRIPTION
Thanks for all of the great work on this library!

I noticed that the docs indicate the types for `checkModel` and `direction` only accept a limited set of strings. I thought it would be worth encoding those in the TS types. This updates index.d.ts to make that happen.