### PR TITLE
Keep all original node props in flatnodes

### DIFF
--- a/src/js/NodeModel.js
+++ b/src/js/NodeModel.js
@@ -50,9 +50,7 @@ class NodeModel {
             }
 
             this.flatNodes[node.value] = {
-                label: node.label,
-                value: node.value,
-                children: node.children,
+                ...node,
                 parent,
                 isChild: parent.value !== undefined,
                 isParent,


### PR DESCRIPTION
The purpose of this change is to keep all properties from the original node defined in the `nodes` prop passed into `CheckboxTree` in the node in the `flatNodes` node.

Because the `nodes` property passed to `CheckboxTree` is a "tree" object and not a "flattened" tree in an array, the original node from the `nodes` prop cannot be accessed easily.

My reasoning is that while some of these properties are not needed in `CheckboxTree`, they may be needed when the `onCheck` event is caught. The event handler is passed `checked` and the `targetNode` from the `flatNodes` representation of the tree. Some of the properties of the  original node may be needed when processing the event and would be included with this change.