### PR TITLE
Fix TypeScript type exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   "exports": {
     ".": {
       "import": "./lib/index.esm.js",
-      "require": "./lib/index.js"
+      "require": "./lib/index.js",
+      "types": "./src/index.d.ts"
     },
     "./*": "./*"
   },


### PR DESCRIPTION
This is needed with certain TS versions/configurations (probably `moduleResolution`?), otherwise you get this error when trying to import the package:

```
Could not find a declaration file for module 'react-checkbox-tree'. '.../node_modules/.pnpm/react-checkbox-tree@2.0.0_react@19.2.0/node_modules/react-checkbox-tree/lib/index.esm.js' implicitly has an 'any' type.
  There are types at '.../node_modules/react-checkbox-tree/src/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'react-checkbox-tree' library may need to update its package.json or typings.ts(7016)
```